### PR TITLE
Fix http .md links being converted

### DIFF
--- a/g2e.py
+++ b/g2e.py
@@ -122,7 +122,7 @@ def fix_relative_links(text):
     # TODO This will break with English tutorials!
     # Also, this is very hacky :(
     text = re.sub(r'([{}])', r'\1\1', text)
-    text = re.sub(r'\[\[(\./)?([^\|]+)\.md\|([^]]*)\]\]',
+    text = re.sub(r'\[\[(\./)?([^\|:]+)\.md\|([^]]*)\]\]',
                   r'[[{links[\2]}|\3]]', text)
     return text.format(links=RelLinkerFakeDict())
 


### PR DESCRIPTION
Now if the link contains :, it's not converted

This is for the OctoPrint readme link, check previous travis logs. 