### PR TITLE
Workaround links in subdirs

### DIFF
--- a/g2e.py
+++ b/g2e.py
@@ -86,6 +86,10 @@ class RelLinkerFakeDict(dict):
         try:
             return dokuwiki_link(key, RELATIONS[key])
         except KeyError:
+            # Hack: try subdirectories
+            for k in RELATIONS.keys():
+                if k.endswith(f'/{key}'):
+                    return dokuwiki_link(k, RELATIONS[k])
             print('Warning: Cannot resolve link', key, file=sys.stderr)
             return 'deadlink'
 
@@ -123,7 +127,7 @@ def fix_relative_links(text):
     # TODO This will break with English tutorials!
     # Also, this is very hacky :(
     text = re.sub(r'([{}])', r'\1\1', text)
-    text = re.sub(r'\[\[(\./)?([^\|:]+)\.md\|([^]]*)\]\]',
+    text = re.sub(r'\[\[(\.\.?/)?([^\|:]+)\.md\|([^]]*)\]\]',
                   r'[[{links[\2]}|\3]]', text)
     return text.format(links=RelLinkerFakeDict())
 


### PR DESCRIPTION
If a link starts with `../`, ignore that part.

If a link is not found in `RELATIONS`, find a key that ends with slash + link name.

This **will** break once we have files with identical filenames in different directories, but it works now.

Proper fix will need to pass current file path to the `fix_relative_links()` function and also to modify `RelLinkerFakeDict`.

Let's not go there just yet.