### PR TITLE
Make sure the Slic3r config bundles have correct presets

### DIFF
--- a/configs/bridges/slic3r_config_bundle.ini
+++ b/configs/bridges/slic3r_config_bundle.ini
@@ -19,9 +19,8 @@ temperature = 231
 
 [presets]
 filament = ABS ESUN 1.75mm.ini
-filament_1 = PLA D
 print = Normal.ini
-printer = prusaNozzle.ini
+printer = RebeliX.ini
 
 [print:Normal]
 avoid_crossing_perimeters = 0

--- a/configs/printing/slic3r_config_bundle.ini
+++ b/configs/printing/slic3r_config_bundle.ini
@@ -19,9 +19,8 @@ temperature = 231
 
 [presets]
 filament = ABS ESUN 1.75mm.ini
-filament_1 = PLA D
 print = Normal.ini
-printer = prusaNozzle.ini
+printer = RebeliX.ini
 
 [print:Normal]
 avoid_crossing_perimeters = 0


### PR DESCRIPTION
This has been a problem for ages. Students always forget to change the printer to RebeliX after loading the bundle.